### PR TITLE
Allow custom metaclasses by relaxing _verify_type

### DIFF
--- a/pinject/object_graph.py
+++ b/pinject/object_graph.py
@@ -170,7 +170,7 @@ def new_object_graph(
 
 
 def _verify_type(elt, required_type, arg_name):
-    if type(elt) != required_type:
+    if not issubclass(type(elt), required_type):
         raise errors.WrongArgTypeError(
             arg_name, required_type.__name__, type(elt).__name__)
 
@@ -181,7 +181,7 @@ def _verify_types(seq, required_type, arg_name):
             arg_name, 'sequence (of {0})'.format(required_type.__name__),
             type(seq).__name__)
     for idx, elt in enumerate(seq):
-        if type(elt) != required_type:
+        if not issubclass(type(elt), required_type):
             raise errors.WrongArgElementTypeError(
                 arg_name, idx, required_type.__name__, type(elt).__name__)
 


### PR DESCRIPTION
Hiya, I made a small change to get Pinject to work with Cloud Endpoints where I wanted to provide my API class which inherits from `remote.Service` which in turn has `_ServiceClass` set as metaclass.

So `_verify_type(cls, types.TypeType, 'cls')` on object_graph.py:234 (where cls is subclass of `remote.Service` will fail because its type is `_ServiceClass` and not the required `types.TypeType`. I've changed the check the verify that the type is a subclass of required type rather than requiring an exact match.

This makes it works for me but honestly I don't yet know if it has any side effects down the road.

Cheers for a nice lib. :tada: 