### PR TITLE
Close v0.10.2 and prepare v0.11.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ from distutils.core import setup
 
 
 setup(name='pinject',
-      version='0.10.2',
+      version='0.11.0',
       description='A pythonic dependency injection library',
       author='Kurt Steinkraus',
       author_email='kurt@steinkraus.us',


### PR DESCRIPTION
For stability sale, v0.10.2 will be closed. The development version becomes v0.11.0. This latest version will contain considerable changes that may break consumers such as support for Python 3.