### PR TITLE
setup.py loads version information from VERSION

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-include LICENSE README.rst
+include LICENSE README.rst VERSION
 recursive-include pinject *.py
 recursive-exclude pinject *_test.py

--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+import os
 from setuptools import setup
-from pinject import (
-    __version__,
-)
+
+# Extra __version__ from VERSION instead of pinject.version so pip doen't
+# import __init__.py and bump into dependencies that haven't been installed
+# yet.
+with open(os.path.join(os.path.dirname(__file__), "VERSION")) as VERSION:
+    __version__ = VERSION.read().strip()
 
 setup(name='pinject',
       version=__version__,


### PR DESCRIPTION
Previously, setup.py would import the version information from
pinject.version. This would trigger pinject's __init__.py to import and
load, which would take a roundabout path to importing the decorator
dependency. The setup.py script is launched by pip while inspecting the
package and dependencies, so this problem will come up in a package
sourcing pinject as a dependency even if decorator is declared as a
dependency in that package.

Referencing:
https://packaging.python.org/guides/single-sourcing-package-version/#single-sourcing-the-version

The previous method was similar to number 6 (setting the value of
__version__ and then importing it). It was changed to number 4 (placing
the version in a VERSION file that is read from disk).

Given there is a parent VERSION file that is connected to the Makefile,
this file is now sourced by setup.py. To ensure it is available when
installing pinject, the VERSION file was also added to the manifest. The
existing version.py convention is kept for regular use by pinject since
that file is readily available to the package when running its source
normally.

This should fix issue #35.