### PR TITLE
Catch NameError resulting from calling isinstance() on SWIG global cv…

### DIFF
--- a/pinject/finding.py
+++ b/pinject/finding.py
@@ -44,6 +44,14 @@ def _get_explicit_or_default_modules(modules):
 def _find_classes_in_module(module):
     classes = set()
     for member_name, member in inspect.getmembers(module):
-        if inspect.isclass(member) and not member_name == '__class__':
-            classes.add(member)
+        try:
+            if inspect.isclass(member) and not member_name == '__class__':
+                classes.add(member)
+        except NameError:
+            # In Python 3 calling isinstance() on SWIG's global cvar property
+            # raises:
+            #     "NameError: Unknown C global variable"
+            # In that case just continue, otherwise let the Error through.
+            if not member_name == 'cvar':
+                raise
     return classes

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,5 @@
 # dev deps
+mock>=4.0.2
 pytest>=3.8.0
 
 # prod deps

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 # dev deps
-mock>=4.0.2
+mock>=3.0.5
 pytest>=3.8.0
 
 # prod deps


### PR DESCRIPTION
…ar in Python 3.

I couldn't think of a way to add a unit test without requiring a SWIG dependency, and other examples of handling this issue didn't provide any examples (https://github.com/numpy/numpy/commit/51a1895234b25b8bf0ace24b8ee881a91c39601c). WDYT?